### PR TITLE
Fix extra closing tag in contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,6 @@
 					</ul>
 				</form>
 			</article>
-			</article>
 
 			<!-- Contact -->
 			<article id="CV" style="zoom: 1;">


### PR DESCRIPTION
## Summary
- remove stray `</article>` closing tag that broke the layout

## Testing
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e94536c8321b0cb099ce0cc7669