### PR TITLE
Add dynamic GitHub project grid with tests

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1416,10 +1416,10 @@ t
 
 				#header nav ul li a {
 					display: block;
-					min-width: 7.5rem;
+					min-width: 9.25rem;
 					height: 2.75rem;
 					line-height: 2.75rem;
-					/* padding: 0 1.25rem 0 1.25rem; */
+					padding: 0 1.5rem;
 					text-transform: uppercase;
 					letter-spacing: 0.2rem;
 					font-size: 0.8rem;
@@ -1556,6 +1556,7 @@ t
 							line-height: 3rem;
 							min-width: 0;
 							width: 100%;
+							padding: 0 1.25rem;
 						}
 
 				#header nav.use-middle:after {
@@ -1607,7 +1608,7 @@ t
 			transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 			padding: 1.5rem 1rem 1.5rem 1rem ;
 			position: relative;
-			width: 40rem;
+			width: 48rem;
 			max-width: 100%;
 			background-color: rgba(27, 31, 34, 0.85);
 			border-radius: 4px;
@@ -1778,24 +1779,51 @@ t
         max-width: 48rem;
 }
 
-.github-projects__grid {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-}
-
 .github-projects__card {
         background: rgba(25, 25, 50, 0.75);
         border-radius: 0.75rem;
         padding: 1.5rem;
         border: 1px solid rgba(255, 255, 255, 0.08);
         box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.25);
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        transition: transform 0.3s ease, box-shadow 0.2s ease, opacity 0.3s ease;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        width: min(100%, 48rem);
+        margin: 0 auto;
+        box-sizing: border-box;
+        min-height: 32rem;
 }
 
 .github-projects__card:hover {
         transform: translateY(-4px);
         box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.github-projects__loader {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 12rem;
+}
+
+.github-projects__spinner {
+        width: 2.75rem;
+        height: 2.75rem;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.18);
+        border-top-color: rgba(255, 255, 255, 0.85);
+        animation: github-projects-spin 0.9s linear infinite;
+}
+
+@keyframes github-projects-spin {
+        from {
+                transform: rotate(0);
+        }
+
+        to {
+                transform: rotate(360deg);
+        }
 }
 
 .github-projects__card-title {
@@ -1804,11 +1832,25 @@ t
         color: #ffffff;
 }
 
+.github-projects__section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+}
+
+.github-projects__section-heading {
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.1em;
+        color: rgba(255, 255, 255, 0.6);
+        margin: 0;
+}
+
 .github-projects__card-description {
         color: rgba(255, 255, 255, 0.8);
         font-size: 0.95rem;
         line-height: 1.5;
-        margin-bottom: 1.25rem;
+        margin: 0;
 }
 
 .github-projects__card-meta {
@@ -1817,11 +1859,143 @@ t
         margin-bottom: 1.25rem;
 }
 
+.github-projects__stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+        gap: 0.65rem 1.5rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+
+.github-projects__stat-label {
+        display: block;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba(255, 255, 255, 0.55);
+}
+
+.github-projects__stat-value {
+        display: block;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.9);
+        font-size: 0.95rem;
+}
+
+.github-projects__readme {
+        color: rgba(255, 255, 255, 0.75);
+        font-size: 0.9rem;
+        line-height: 1.5;
+        margin: 0;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        min-height: 16rem;
+        max-height: 18rem;
+        overflow-y: auto;
+        padding-right: 0.35rem;
+        padding-bottom: 0.5rem;
+}
+
+.github-projects__readme::-webkit-scrollbar {
+        width: 0.4rem;
+}
+
+.github-projects__readme::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 0.25rem;
+}
+
+.github-projects__readme h1,
+.github-projects__readme h2,
+.github-projects__readme h3,
+.github-projects__readme h4 {
+        font-size: 1.05rem;
+        margin: 1rem 0 0.5rem;
+        color: rgba(255, 255, 255, 0.9);
+}
+
+.github-projects__readme p {
+        margin: 0.75rem 0;
+}
+
+.github-projects__readme a {
+        color: #9ecbff;
+        text-decoration: underline;
+        word-break: break-word;
+}
+
+.github-projects__readme ul,
+.github-projects__readme ol {
+        padding-left: 1.25rem;
+        margin: 0.75rem 0;
+}
+
+.github-projects__readme code {
+        background: rgba(255, 255, 255, 0.08);
+        border-radius: 0.35rem;
+        padding: 0.25rem 0.4rem;
+        font-size: 0.85rem;
+}
+
+.github-projects__readme pre {
+        background: rgba(10, 10, 30, 0.75);
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+}
+
+.github-projects__readme blockquote {
+        border-left: 0.2rem solid rgba(255, 255, 255, 0.25);
+        margin: 0.75rem 0;
+        padding-left: 0.75rem;
+        color: rgba(255, 255, 255, 0.65);
+        font-style: italic;
+}
+
+.github-projects__readme img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 1rem auto;
+        border-radius: 0.5rem;
+        box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.35);
+}
+
+.github-projects__readme--empty {
+        opacity: 0.6;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 1rem;
+}
+
+.github-projects__readme--empty a {
+        color: rgba(255, 255, 255, 0.8);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.75rem;
+        font-weight: 600;
+}
+
+.github-projects__links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        margin-top: auto;
+}
+
 .github-projects__card-link {
         font-weight: 600;
         letter-spacing: 0.04em;
         text-transform: uppercase;
         font-size: 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
 }
 
 .github-projects__status {
@@ -1831,4 +2005,127 @@ t
 
 .github-projects__status--error {
         color: #ff9f9f;
+}
+
+.github-projects__status--error a {
+        color: #ff9f9f;
+        text-decoration: underline;
+        font-weight: 600;
+}
+
+.github-projects__carousel {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 1.5rem;
+        align-items: center;
+}
+
+.github-projects__carousel-card {
+        width: 100%;
+        position: relative;
+        overflow: hidden;
+        min-height: 18rem;
+        display: flex;
+        align-items: stretch;
+}
+
+.github-projects__card--enter-next {
+        transform: translateX(25%);
+        opacity: 0;
+}
+
+.github-projects__card--enter-prev {
+        transform: translateX(-25%);
+        opacity: 0;
+}
+
+.github-projects__card--enter-active {
+        transform: translateX(0);
+        opacity: 1;
+}
+
+.github-projects__nav {
+        width: 3.15rem;
+        height: 3.15rem;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background: rgba(10, 10, 30, 0.6);
+        color: #ffffff;
+        font-size: 1.75rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+}
+
+.github-projects__nav:hover {
+        background: rgba(35, 35, 80, 0.8);
+        border-color: rgba(255, 255, 255, 0.45);
+        transform: translateY(-2px);
+}
+
+.github-projects__nav:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.8);
+        outline-offset: 2px;
+}
+
+.github-projects__nav:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+        transform: none;
+}
+
+.github-projects__position {
+        grid-column: 1 / -1;
+        text-align: center;
+        color: rgba(255, 255, 255, 0.6);
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+}
+
+@media screen and (max-width: 980px) {
+        .github-projects__carousel {
+                display: flex;
+                flex-direction: column;
+                align-items: stretch;
+        }
+
+        .github-projects__nav {
+                order: 1;
+        }
+
+        .github-projects__nav--previous {
+                align-self: flex-start;
+        }
+
+        .github-projects__nav--next {
+                align-self: flex-end;
+        }
+
+        .github-projects__carousel-card {
+                order: 0;
+        }
+
+        .github-projects__position {
+                order: 2;
+        }
+}
+
+@media screen and (max-width: 736px) {
+        .github-projects__card {
+                padding: 1.25rem;
+                min-height: 28rem;
+        }
+
+        .github-projects__nav {
+                width: 2.75rem;
+                height: 2.75rem;
+                font-size: 1.5rem;
+        }
+
+        .github-projects__stats {
+                grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+        }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1767,3 +1767,68 @@ t
 }
 
 
+
+.github-projects {
+        margin-bottom: 3rem;
+}
+
+.github-projects__intro {
+        color: rgba(255, 255, 255, 0.75);
+        margin-bottom: 2rem;
+        max-width: 48rem;
+}
+
+.github-projects__grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.github-projects__card {
+        background: rgba(25, 25, 50, 0.75);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.github-projects__card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.github-projects__card-title {
+        font-size: 1.25rem;
+        margin-bottom: 0.75rem;
+        color: #ffffff;
+}
+
+.github-projects__card-description {
+        color: rgba(255, 255, 255, 0.8);
+        font-size: 0.95rem;
+        line-height: 1.5;
+        margin-bottom: 1.25rem;
+}
+
+.github-projects__card-meta {
+        color: rgba(255, 255, 255, 0.65);
+        font-size: 0.85rem;
+        margin-bottom: 1.25rem;
+}
+
+.github-projects__card-link {
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+}
+
+.github-projects__status {
+        color: rgba(255, 255, 255, 0.75);
+        font-size: 0.95rem;
+}
+
+.github-projects__status--error {
+        color: #ff9f9f;
+}

--- a/assets/js/githubProjects.js
+++ b/assets/js/githubProjects.js
@@ -13,11 +13,16 @@
 
             return {
                 name: pinnedRepo.repo || pinnedRepo.name || 'Untitled Project',
-                description: pinnedRepo.description || 'No description provided.',
+                description: pinnedRepo.description || '',
                 language: pinnedRepo.language || 'Not specified',
                 url: pinnedRepo.link || pinnedRepo.url || '#',
                 stars: Number.isFinite(starValue) ? starValue : 0,
-                updatedAt: pinnedRepo.updated_at || null
+                updatedAt: pinnedRepo.updated_at || null,
+                forks: typeof pinnedRepo.forks === 'number' ? pinnedRepo.forks : 0,
+                openIssues: typeof pinnedRepo.open_issues === 'number' ? pinnedRepo.open_issues : 0,
+                watchers: typeof pinnedRepo.watchers === 'number' ? pinnedRepo.watchers : null,
+                defaultBranch: pinnedRepo.default_branch || null,
+                homepage: pinnedRepo.homepage || null
             };
         }
 
@@ -28,10 +33,15 @@
 
             return {
                 name: githubRepo.name || 'Untitled Project',
-                description: githubRepo.description || 'No description provided.',
+                description: githubRepo.description || '',
                 language: githubRepo.language || 'Not specified',
                 url: githubRepo.html_url || '#',
                 stars: typeof githubRepo.stargazers_count === 'number' ? githubRepo.stargazers_count : 0,
+                forks: typeof githubRepo.forks_count === 'number' ? githubRepo.forks_count : 0,
+                openIssues: typeof githubRepo.open_issues_count === 'number' ? githubRepo.open_issues_count : 0,
+                watchers: typeof githubRepo.watchers_count === 'number' ? githubRepo.watchers_count : null,
+                defaultBranch: githubRepo.default_branch || null,
+                homepage: githubRepo.homepage || null,
                 updatedAt: githubRepo.pushed_at || githubRepo.updated_at || null
             };
         }
@@ -50,10 +60,12 @@
 
             this.fetcher = options.fetch || defaultFetch;
             this.pinnedServiceUrl = options.pinnedServiceUrl || 'https://gh-pinned-repos.egoist.dev/';
-            this.repoLimit = options.repoLimit || 6;
+            const limitOption = options.repoLimit;
+            this.repoLimit = Number.isInteger(limitOption) && limitOption > 0 ? limitOption : null;
         }
 
         async fetchRepositories() {
+            let repositories = [];
             try {
                 const pinnedRepos = await this.fetchPinnedRepositories();
                 if (Array.isArray(pinnedRepos) && pinnedRepos.length > 0) {
@@ -61,13 +73,25 @@
                         username: this.username,
                         total: pinnedRepos.length
                     });
-                    return pinnedRepos.slice(0, this.repoLimit);
+                    repositories = pinnedRepos;
                 }
             } catch (error) {
                 console.warn('[GitHubProjects] Failed to load pinned repositories, falling back to GitHub API.', error);
             }
 
-            return this.fetchFromGitHubApi();
+            if (!repositories.length) {
+                repositories = await this.fetchFromGitHubApi();
+            }
+
+            const filtered = this.filterExcluded(repositories);
+            const sorted = this.sortRepositories(filtered);
+            const limited = this.applyRepoLimit(sorted);
+            const enriched = await this.enrichRepositories(limited);
+            console.info('[GitHubProjects] Rendering GitHub API repositories.', {
+                username: this.username,
+                total: enriched.length
+            });
+            return enriched;
         }
 
         async fetchPinnedRepositories() {
@@ -130,38 +154,172 @@
             }
 
             const filtered = data.filter((repo) => !repo.fork);
-            const normalized = filtered.map((repo) => RepositoryNormalizer.fromGitHub(repo));
-            normalized.sort((a, b) => b.stars - a.stars || new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0));
-            console.info('[GitHubProjects] Rendering GitHub API repositories.', {
-                username: this.username,
-                total: normalized.length
+            return filtered.map((repo) => RepositoryNormalizer.fromGitHub(repo));
+        }
+
+        sortRepositories(repositories = []) {
+            return [...repositories].sort((a, b) => {
+                const starDelta = (b.stars || 0) - (a.stars || 0);
+                if (starDelta !== 0) {
+                    return starDelta;
+                }
+                const dateA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+                const dateB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+                return dateB - dateA;
             });
-            return normalized.slice(0, this.repoLimit);
+        }
+
+        filterExcluded(repositories = []) {
+            const excludedNames = new Set(['ameer-jamal', 'ameer-jamal.github.io']);
+            return repositories.filter((repo) => {
+                if (!repo || !repo.name) {
+                    return false;
+                }
+                const normalized = String(repo.name).trim().toLowerCase();
+                return !excludedNames.has(normalized);
+            });
+        }
+
+        applyRepoLimit(repositories = []) {
+            if (!this.repoLimit) {
+                return repositories;
+            }
+            return repositories.slice(0, this.repoLimit);
+        }
+
+        async enrichRepositories(repositories = []) {
+            if (!repositories.length) {
+                return [];
+            }
+
+            const enriched = await Promise.all(repositories.map(async (repo) => {
+                try {
+                    const readme = await this.fetchReadme(repo);
+                    return Object.assign({}, repo, {
+                        readmeRaw: readme ? readme.text : null,
+                        readmeHtmlUrl: readme && readme.htmlUrl ? readme.htmlUrl : repo.url,
+                        readmeRawUrl: readme && readme.rawUrl ? readme.rawUrl : null,
+                        readmeRawBaseUrl: readme && readme.rawBaseUrl ? readme.rawBaseUrl : null,
+                        readmeHtmlBaseUrl: readme && readme.htmlBaseUrl ? readme.htmlBaseUrl : null
+                    });
+                } catch (error) {
+                    console.warn('[GitHubProjects] Unable to load README for repository.', {
+                        repo: repo.name,
+                        message: error && error.message ? error.message : 'Unknown error'
+                    });
+                    return Object.assign({}, repo, {
+                        readmeRaw: null,
+                        readmeHtmlUrl: repo.url,
+                        readmeRawUrl: null,
+                        readmeRawBaseUrl: null,
+                        readmeHtmlBaseUrl: null
+                    });
+                }
+            }));
+
+            return enriched;
+        }
+
+        async fetchReadme(repo) {
+            if (!repo || !repo.name) {
+                return null;
+            }
+
+            const repoName = repo.name;
+            const encodedName = encodeURIComponent(repoName);
+            const url = `https://api.github.com/repos/${this.username}/${encodedName}/readme`;
+
+            console.info('[GitHubProjects] Requesting repository README.', {
+                username: this.username,
+                repository: repoName,
+                url
+            });
+
+            let response;
+            try {
+                response = await this.fetcher(url);
+            } catch (error) {
+                console.error('[GitHubProjects] Network error while fetching README.', {
+                    repository: repoName
+                }, error);
+                throw error;
+            }
+
+            if (response.status === 404) {
+                console.info('[GitHubProjects] README not found for repository.', {
+                    repository: repoName
+                });
+                return null;
+            }
+
+            if (!response.ok) {
+                const status = typeof response.status === 'number' ? response.status : 'unknown';
+                const statusText = response.statusText || 'No status text';
+                throw new Error(`README request failed (${status} ${statusText})`);
+            }
+
+            const data = await response.json();
+            if (!data || typeof data !== 'object') {
+                return null;
+            }
+
+            const encoding = data.encoding || 'base64';
+            const content = typeof data.content === 'string'
+                ? decodeReadmeContent(data.content, encoding)
+                : null;
+
+            return {
+                text: content ? content.trim() : null,
+                htmlUrl: data.html_url || data.download_url || repo.url,
+                rawUrl: data.download_url || null,
+                rawBaseUrl: deriveBaseUrl(data.download_url),
+                htmlBaseUrl: deriveBaseUrl(data.html_url)
+            };
         }
     }
 
     class RepoRenderer {
-        constructor(container, doc = document) {
+        constructor(container, { doc = document, username = null } = {}) {
             if (!container) {
                 throw new Error('A container element is required');
             }
             this.container = container;
             this.doc = doc;
+            this.username = username;
         }
 
         renderLoading() {
             this.container.innerHTML = '';
-            const loading = this.doc.createElement('p');
-            loading.className = 'github-projects__status';
-            loading.textContent = 'Loading GitHub projects...';
-            this.container.appendChild(loading);
+            const loader = this.doc.createElement('div');
+            loader.className = 'github-projects__loader';
+
+            const spinner = this.doc.createElement('div');
+            spinner.className = 'github-projects__spinner';
+            spinner.setAttribute('role', 'status');
+            spinner.setAttribute('aria-label', 'Loading GitHub projects');
+
+            loader.appendChild(spinner);
+            this.container.appendChild(loader);
         }
 
-        renderError(message) {
+        renderError({ message, showLink } = {}) {
             this.container.innerHTML = '';
-            const error = this.doc.createElement('p');
+            const error = this.doc.createElement('div');
             error.className = 'github-projects__status github-projects__status--error';
-            error.textContent = message;
+
+            if (showLink && this.username) {
+                const link = this.doc.createElement('a');
+                link.href = `https://github.com/${this.username}?tab=repositories`;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = 'Click here to view my GitHub projects';
+                error.appendChild(link);
+            } else if (message) {
+                error.textContent = message;
+            } else {
+                error.textContent = 'Something went wrong. Please try again later.';
+            }
+
             this.container.appendChild(error);
         }
 
@@ -172,43 +330,477 @@
                 console.info('[GitHubProjects] No repositories available after fetch.', {
                     total: repositories ? repositories.length : 0
                 });
-                this.renderError('No public projects found just yet. Please check back soon!');
+                this.renderError({ message: 'No public projects found just yet. Please check back soon!' });
                 return;
             }
 
-            repositories.forEach((repo) => {
-                const card = this.doc.createElement('article');
-                card.className = 'github-projects__card';
+            const markdownRenderer = new MarkdownRenderer({ doc: this.doc });
+            const carousel = new RepoCarousel(this.doc, repositories, {
+                markdownRenderer,
+                username: this.username
+            });
+            this.container.appendChild(carousel.getElement());
+        }
+    }
 
-                const title = this.doc.createElement('h4');
-                title.className = 'github-projects__card-title';
-                title.textContent = repo.name;
+    class RepoCarousel {
+        constructor(doc, repositories, options = {}) {
+            this.doc = doc;
+            this.repositories = Array.isArray(repositories) ? repositories : [];
+            this.total = this.repositories.length;
+            this.currentIndex = 0;
+            this.markdownRenderer = options.markdownRenderer || new MarkdownRenderer({ doc: this.doc });
+            this.username = options.username || null;
+
+            this.root = this.doc.createElement('div');
+            this.root.className = 'github-projects__carousel';
+
+            this.prevButton = this.createNavButton('previous', '‹');
+            this.nextButton = this.createNavButton('next', '›');
+
+            this.cardHost = this.doc.createElement('div');
+            this.cardHost.className = 'github-projects__carousel-card';
+
+            this.positionIndicator = this.doc.createElement('p');
+            this.positionIndicator.className = 'github-projects__position';
+
+            this.root.appendChild(this.prevButton);
+            this.root.appendChild(this.cardHost);
+            this.root.appendChild(this.nextButton);
+            this.root.appendChild(this.positionIndicator);
+
+            this.prevButton.addEventListener('click', () => this.goToPrevious());
+            this.nextButton.addEventListener('click', () => this.goToNext());
+
+            this.update();
+        }
+
+        getElement() {
+            return this.root;
+        }
+
+        goToPrevious() {
+            if (this.total <= 1) {
+                return;
+            }
+            this.currentIndex = (this.currentIndex - 1 + this.total) % this.total;
+            this.update(-1);
+        }
+
+        goToNext() {
+            if (this.total <= 1) {
+                return;
+            }
+            this.currentIndex = (this.currentIndex + 1) % this.total;
+            this.update(1);
+        }
+
+        update(direction = 0) {
+            this.cardHost.innerHTML = '';
+
+            if (!this.total) {
+                const fallback = this.doc.createElement('p');
+                fallback.className = 'github-projects__status';
+                fallback.textContent = 'No repositories to display.';
+                this.cardHost.appendChild(fallback);
+                this.prevButton.disabled = true;
+                this.nextButton.disabled = true;
+                this.positionIndicator.textContent = '';
+                return;
+            }
+
+            const repo = this.repositories[this.currentIndex];
+            const card = this.createCard(repo);
+            if (direction > 0) {
+                card.classList.add('github-projects__card--enter-next');
+            } else if (direction < 0) {
+                card.classList.add('github-projects__card--enter-prev');
+            }
+            this.cardHost.appendChild(card);
+
+            if (direction !== 0) {
+                const win = this.doc && this.doc.defaultView ? this.doc.defaultView : null;
+                const scheduler = win && typeof win.requestAnimationFrame === 'function'
+                    ? win.requestAnimationFrame.bind(win)
+                    : (typeof requestAnimationFrame === 'function'
+                        ? requestAnimationFrame
+                        : (callback) => setTimeout(callback, 0));
+                scheduler(() => {
+                    card.classList.add('github-projects__card--enter-active');
+                });
+                card.addEventListener('transitionend', () => {
+                    card.classList.remove('github-projects__card--enter-next', 'github-projects__card--enter-prev', 'github-projects__card--enter-active');
+                }, { once: true });
+            }
+
+            const disableNav = this.total <= 1;
+            this.prevButton.disabled = disableNav;
+            this.nextButton.disabled = disableNav;
+            this.positionIndicator.textContent = `Project ${this.currentIndex + 1} of ${this.total}`;
+        }
+
+        createNavButton(direction, label) {
+            const button = this.doc.createElement('button');
+            button.type = 'button';
+            button.className = `github-projects__nav github-projects__nav--${direction}`;
+            button.setAttribute('aria-label', `${direction === 'previous' ? 'Previous' : 'Next'} project`);
+            button.textContent = label;
+            return button;
+        }
+
+        createCard(repo) {
+            const card = this.doc.createElement('div');
+            card.className = 'github-projects__card';
+
+            const title = this.doc.createElement('h4');
+            title.className = 'github-projects__card-title';
+            title.textContent = repo.name;
+
+            if (repo.description && repo.description.trim().length > 0) {
+                const descriptionSection = this.doc.createElement('div');
+                descriptionSection.className = 'github-projects__section';
+
+                const descriptionHeading = this.doc.createElement('h5');
+                descriptionHeading.className = 'github-projects__section-heading';
+                descriptionHeading.textContent = 'Description';
 
                 const description = this.doc.createElement('p');
                 description.className = 'github-projects__card-description';
                 description.textContent = repo.description;
 
-                const meta = this.doc.createElement('p');
-                meta.className = 'github-projects__card-meta';
-                const language = repo.language ? `${repo.language}` : 'Not specified';
-                const stars = `${repo.stars}★`;
-                const updated = repo.updatedAt ? new Date(repo.updatedAt).toLocaleDateString() : 'Recently updated';
-                meta.textContent = `${language} • ${stars} • ${updated}`;
+                descriptionSection.appendChild(descriptionHeading);
+                descriptionSection.appendChild(description);
+                card.appendChild(descriptionSection);
+            }
 
-                const link = this.doc.createElement('a');
-                link.className = 'github-projects__card-link';
-                link.href = repo.url;
-                link.target = '_blank';
-                link.rel = 'noopener';
-                link.textContent = 'View on GitHub';
+            const meta = this.doc.createElement('div');
+            meta.className = 'github-projects__card-meta';
+            const stats = this.doc.createElement('ul');
+            stats.className = 'github-projects__stats';
+            stats.appendChild(this.createStatItem('Language', repo.language || 'Not specified'));
+            if ((repo.stars || 0) > 0) {
+                stats.appendChild(this.createStatItem('Stars', formatNumber(repo.stars)));
+            }
+            if ((repo.forks || 0) > 0) {
+                stats.appendChild(this.createStatItem('Forks', formatNumber(repo.forks)));
+            }
+            if ((repo.openIssues || 0) > 0) {
+                stats.appendChild(this.createStatItem('Open Issues', formatNumber(repo.openIssues)));
+            }
+            if ((repo.watchers || 0) > 0) {
+                stats.appendChild(this.createStatItem('Watchers', formatNumber(repo.watchers)));
+            }
+            stats.appendChild(this.createStatItem('Updated', repo.updatedAt ? new Date(repo.updatedAt).toLocaleDateString() : 'Recently updated'));
+            meta.appendChild(stats);
 
-                card.appendChild(title);
-                card.appendChild(description);
-                card.appendChild(meta);
-                card.appendChild(link);
+            const readme = this.doc.createElement('div');
+            readme.className = 'github-projects__readme';
+            const readmeHtml = this.renderReadme(repo);
+            if (readmeHtml) {
+                readme.innerHTML = readmeHtml;
+            } else {
+                readme.classList.add('github-projects__readme--empty');
+                if (this.username) {
+                    const fallbackLink = this.doc.createElement('a');
+                    fallbackLink.href = `https://github.com/${this.username}?tab=repositories`;
+                    fallbackLink.target = '_blank';
+                    fallbackLink.rel = 'noopener';
+                    fallbackLink.textContent = 'Explore the full project on GitHub';
+                    readme.appendChild(fallbackLink);
+                }
+            }
 
-                this.container.appendChild(card);
+            const actions = this.doc.createElement('div');
+            actions.className = 'github-projects__links';
+
+            const repoLink = this.doc.createElement('a');
+            repoLink.className = 'github-projects__card-link';
+            repoLink.href = repo.url;
+            repoLink.target = '_blank';
+            repoLink.rel = 'noopener';
+            repoLink.textContent = 'View Repository';
+
+            actions.appendChild(repoLink);
+
+            if (repo.homepage) {
+                const demoLink = this.doc.createElement('a');
+                demoLink.className = 'github-projects__card-link';
+                demoLink.href = repo.homepage;
+                demoLink.target = '_blank';
+                demoLink.rel = 'noopener';
+                demoLink.textContent = 'View Live Site';
+                actions.appendChild(demoLink);
+            }
+
+
+            card.appendChild(title);
+            card.appendChild(meta);
+            card.appendChild(readme);
+            card.appendChild(actions);
+
+            return card;
+        }
+
+        createStatItem(label, value) {
+            const item = this.doc.createElement('li');
+            const labelSpan = this.doc.createElement('span');
+            labelSpan.className = 'github-projects__stat-label';
+            labelSpan.textContent = `${label}:`;
+            const valueSpan = this.doc.createElement('span');
+            valueSpan.className = 'github-projects__stat-value';
+            valueSpan.textContent = value;
+            item.appendChild(labelSpan);
+            item.appendChild(valueSpan);
+            return item;
+        }
+
+        renderReadme(repo) {
+            if (!repo || !repo.readmeRaw) {
+                return null;
+            }
+            return this.markdownRenderer.render(repo.readmeRaw, {
+                maxLength: 1400,
+                baseRawUrl: repo.readmeRawBaseUrl,
+                baseHtmlUrl: repo.readmeHtmlBaseUrl
             });
+        }
+    }
+
+    class MarkdownRenderer {
+        constructor({ doc } = {}) {
+            this.doc = doc || (typeof document !== 'undefined' ? document : null);
+            const globalMarked = typeof globalThis !== 'undefined' && globalThis.marked ? globalThis.marked : null;
+            if (globalMarked && typeof globalMarked.parse === 'function') {
+                this.parseMarkdown = (markdown) => globalMarked.parse(markdown, {
+                    mangle: false,
+                    headerIds: false,
+                    breaks: true
+                });
+            } else if (typeof globalMarked === 'function') {
+                this.parseMarkdown = (markdown) => globalMarked(markdown, {
+                    mangle: false,
+                    headerIds: false,
+                    breaks: true
+                });
+            } else {
+                this.parseMarkdown = (markdown) => this.basicMarkdown(markdown);
+            }
+        }
+
+        render(markdown, options = {}) {
+            if (!markdown || typeof markdown !== 'string') {
+                return null;
+            }
+
+            const parsed = this.parseMarkdown(markdown);
+            if (!this.doc) {
+                return parsed;
+            }
+
+            const sanitized = this.sanitize(parsed, options);
+            if (!sanitized) {
+                return null;
+            }
+
+            if (Number.isFinite(options.maxLength)) {
+                return this.truncate(sanitized, options.maxLength);
+            }
+
+            return sanitized;
+        }
+
+        basicMarkdown(markdown) {
+            const escaped = markdown
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            return `<p>${escaped.replace(/\r?\n\r?\n/g, '</p><p>')}</p>`;
+        }
+
+        sanitize(html, context = {}) {
+            if (!this.doc) {
+                return html;
+            }
+
+            const container = this.doc.createElement('div');
+            container.innerHTML = html;
+            const allowedTags = new Set([
+                'a', 'p', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'blockquote',
+                'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'br', 'hr', 'img'
+            ]);
+            const allowedAttributes = {
+                a: new Set(['href', 'title']),
+                img: new Set(['src', 'alt', 'title'])
+            };
+
+            const stack = [container];
+            while (stack.length > 0) {
+                const node = stack.pop();
+                for (let child = node.firstChild; child; ) {
+                    const nextSibling = child.nextSibling;
+                    if (child.nodeType === 8) {
+                        node.removeChild(child);
+                    } else if (child.nodeType === 1) {
+                        const tagName = child.tagName.toLowerCase();
+                        if (!allowedTags.has(tagName)) {
+                            this.unwrapNode(child);
+                        } else {
+                            this.sanitizeAttributes(child, tagName, allowedAttributes, context);
+                            stack.push(child);
+                        }
+                    } else {
+                        stack.push(child);
+                    }
+                    child = nextSibling;
+                }
+            }
+
+            return container.innerHTML.trim();
+        }
+
+        sanitizeAttributes(element, tagName, allowedAttributes, context) {
+            for (let i = element.attributes.length - 1; i >= 0; i -= 1) {
+                const attr = element.attributes[i];
+                const attrName = attr.name.toLowerCase();
+                if (attrName.startsWith('on') || attrName === 'style') {
+                    element.removeAttribute(attr.name);
+                    continue;
+                }
+
+                const allowed = allowedAttributes[tagName];
+                if (allowed && !allowed.has(attrName)) {
+                    element.removeAttribute(attr.name);
+                }
+            }
+
+            if (tagName === 'a') {
+                const safeHref = this.rewriteLink(element.getAttribute('href'), context.baseHtmlUrl);
+                if (!safeHref) {
+                    this.unwrapNode(element);
+                    return;
+                }
+                element.setAttribute('href', safeHref);
+                element.setAttribute('target', '_blank');
+                element.setAttribute('rel', 'noopener');
+            } else if (tagName === 'img') {
+                const safeSrc = this.rewriteMedia(element.getAttribute('src'), context.baseRawUrl);
+                if (!safeSrc) {
+                    element.parentNode.removeChild(element);
+                    return;
+                }
+                element.setAttribute('src', safeSrc);
+                element.setAttribute('loading', 'lazy');
+                element.setAttribute('decoding', 'async');
+            }
+        }
+
+        rewriteLink(href, baseHtmlUrl) {
+            if (!href) {
+                return null;
+            }
+            const trimmed = href.trim();
+            if (!trimmed) {
+                return null;
+            }
+            if (/^javascript:/i.test(trimmed)) {
+                return null;
+            }
+            if (trimmed.startsWith('#')) {
+                return trimmed;
+            }
+            try {
+                return new URL(trimmed, baseHtmlUrl || undefined).toString();
+            } catch (error) {
+                if (/^https?:/i.test(trimmed) || /^mailto:/i.test(trimmed)) {
+                    return trimmed;
+                }
+                return null;
+            }
+        }
+
+        rewriteMedia(src, baseRawUrl) {
+            if (!src) {
+                return null;
+            }
+            const trimmed = src.trim();
+            if (/^javascript:/i.test(trimmed)) {
+                return null;
+            }
+            if (/^https?:/i.test(trimmed) || /^data:image\//i.test(trimmed)) {
+                return trimmed;
+            }
+            try {
+                return new URL(trimmed, baseRawUrl || undefined).toString();
+            } catch (error) {
+                return null;
+            }
+        }
+
+        unwrapNode(element) {
+            const parent = element.parentNode;
+            if (!parent) {
+                return;
+            }
+            while (element.firstChild) {
+                parent.insertBefore(element.firstChild, element);
+            }
+            parent.removeChild(element);
+        }
+
+        truncate(html, limit) {
+            if (!this.doc || !Number.isFinite(limit)) {
+                return html;
+            }
+            const container = this.doc.createElement('div');
+            container.innerHTML = html;
+            let total = 0;
+            const showText = (this.doc.defaultView && this.doc.defaultView.NodeFilter && this.doc.defaultView.NodeFilter.SHOW_TEXT)
+                || (typeof NodeFilter !== 'undefined' ? NodeFilter.SHOW_TEXT : 4);
+            const walker = this.doc.createTreeWalker(container, showText);
+            const nodesToRemove = [];
+
+            while (true) {
+                const node = walker.nextNode();
+                if (!node) {
+                    break;
+                }
+                const text = node.textContent || '';
+                if (!text.trim()) {
+                    continue;
+                }
+
+                if (total + text.length > limit) {
+                    const allowed = limit - total;
+                    if (allowed > 0) {
+                        node.textContent = text.slice(0, allowed).trimEnd() + '…';
+                    } else {
+                        nodesToRemove.push(node);
+                    }
+                    this.collectFollowingNodes(node, container, nodesToRemove);
+                    break;
+                }
+                total += text.length;
+            }
+
+            nodesToRemove.forEach((node) => {
+                if (node.parentNode) {
+                    node.parentNode.removeChild(node);
+                }
+            });
+
+            return container.innerHTML;
+        }
+
+        collectFollowingNodes(node, root, bucket) {
+            let current = node;
+            while (current && current !== root) {
+                let sibling = current.nextSibling;
+                while (sibling) {
+                    bucket.push(sibling);
+                    sibling = sibling.nextSibling;
+                }
+                current = current.parentNode;
+            }
         }
     }
 
@@ -223,7 +815,7 @@
         async init() {
             try {
                 const containerElement = this.getContainer();
-                this.renderer = this.renderer || new RepoRenderer(containerElement);
+                this.renderer = this.renderer || new RepoRenderer(containerElement, { username: this.username });
                 this.apiClient = this.apiClient || new GitHubApiClient(this.username);
 
                 this.renderer.renderLoading();
@@ -232,8 +824,8 @@
             } catch (error) {
                 const containerElement = this.safeGetContainer();
                 if (containerElement) {
-                    const fallbackRenderer = this.renderer || new RepoRenderer(containerElement);
-                    fallbackRenderer.renderError('Unable to load GitHub projects right now. Please try again later.');
+                    const fallbackRenderer = this.renderer || new RepoRenderer(containerElement, { username: this.username });
+                    fallbackRenderer.renderError({ showLink: true });
                 }
                 console.error('[GitHubProjects] Unable to initialize GitHub project section.', error);
             }
@@ -271,10 +863,83 @@
         }
     }
 
+    function decodeReadmeContent(content, encoding) {
+        if (typeof content !== 'string') {
+            return null;
+        }
+
+        if (encoding === 'base64') {
+            try {
+                return decodeBase64(content);
+            } catch (error) {
+                console.warn('[GitHubProjects] Failed to decode base64 README content.', error);
+                return null;
+            }
+        }
+
+        return content;
+    }
+
+    function decodeBase64(input) {
+        if (typeof input !== 'string') {
+            throw new TypeError('input must be a base64 encoded string');
+        }
+
+        if (typeof Buffer !== 'undefined') {
+            return Buffer.from(input, 'base64').toString('utf8');
+        }
+
+        if (typeof globalThis.atob === 'function') {
+            const binary = globalThis.atob(input);
+            const length = binary.length;
+            const bytes = new Uint8Array(length);
+            for (let i = 0; i < length; i += 1) {
+                bytes[i] = binary.charCodeAt(i);
+            }
+            if (typeof TextDecoder !== 'undefined') {
+                return new TextDecoder('utf-8').decode(bytes);
+            }
+            let result = '';
+            for (let i = 0; i < bytes.length; i += 1) {
+                result += String.fromCharCode(bytes[i]);
+            }
+            return result;
+        }
+
+        throw new Error('Base64 decoding is not supported in this environment.');
+    }
+
+    function deriveBaseUrl(url) {
+        if (typeof url !== 'string') {
+            return null;
+        }
+        const trimmed = url.trim();
+        if (!trimmed) {
+            return null;
+        }
+        const lastSlash = trimmed.lastIndexOf('/');
+        if (lastSlash === -1) {
+            return null;
+        }
+        return trimmed.slice(0, lastSlash + 1);
+    }
+
+    function formatNumber(value) {
+        if (!Number.isFinite(value)) {
+            return '0';
+        }
+        if (value >= 1000) {
+            return `${(value / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+        }
+        return String(value);
+    }
+
     const exported = {
         RepositoryNormalizer,
         GitHubApiClient,
+        MarkdownRenderer,
         RepoRenderer,
+        RepoCarousel,
         RepoSectionController
     };
 

--- a/assets/js/githubProjects.js
+++ b/assets/js/githubProjects.js
@@ -1,0 +1,245 @@
+(function (global) {
+    'use strict';
+
+    class RepositoryNormalizer {
+        static fromPinned(pinnedRepo) {
+            if (!pinnedRepo || typeof pinnedRepo !== 'object') {
+                throw new TypeError('pinnedRepo must be an object');
+            }
+
+            const starValue = typeof pinnedRepo.stars === 'number'
+                ? pinnedRepo.stars
+                : Number.parseInt(pinnedRepo.stars, 10);
+
+            return {
+                name: pinnedRepo.repo || pinnedRepo.name || 'Untitled Project',
+                description: pinnedRepo.description || 'No description provided.',
+                language: pinnedRepo.language || 'Not specified',
+                url: pinnedRepo.link || pinnedRepo.url || '#',
+                stars: Number.isFinite(starValue) ? starValue : 0,
+                updatedAt: pinnedRepo.updated_at || null
+            };
+        }
+
+        static fromGitHub(githubRepo) {
+            if (!githubRepo || typeof githubRepo !== 'object') {
+                throw new TypeError('githubRepo must be an object');
+            }
+
+            return {
+                name: githubRepo.name || 'Untitled Project',
+                description: githubRepo.description || 'No description provided.',
+                language: githubRepo.language || 'Not specified',
+                url: githubRepo.html_url || '#',
+                stars: typeof githubRepo.stargazers_count === 'number' ? githubRepo.stargazers_count : 0,
+                updatedAt: githubRepo.pushed_at || githubRepo.updated_at || null
+            };
+        }
+    }
+
+    class GitHubApiClient {
+        constructor(username, options = {}) {
+            if (!username) {
+                throw new Error('username is required');
+            }
+
+            this.username = username;
+            const defaultFetch = typeof global.fetch === 'function'
+                ? global.fetch.bind(global)
+                : () => Promise.reject(new Error('Fetch API is not available in this environment.'));
+
+            this.fetcher = options.fetch || defaultFetch;
+            this.pinnedServiceUrl = options.pinnedServiceUrl || 'https://gh-pinned-repos.egoist.dev/';
+            this.repoLimit = options.repoLimit || 6;
+        }
+
+        async fetchRepositories() {
+            try {
+                const pinnedRepos = await this.fetchPinnedRepositories();
+                if (Array.isArray(pinnedRepos) && pinnedRepos.length > 0) {
+                    return pinnedRepos.slice(0, this.repoLimit);
+                }
+            } catch (error) {
+                console.warn('Failed to load pinned repositories, falling back to GitHub API.', error);
+            }
+
+            return this.fetchFromGitHubApi();
+        }
+
+        async fetchPinnedRepositories() {
+            const url = new URL(this.pinnedServiceUrl);
+            url.searchParams.set('username', this.username);
+
+            const response = await this.fetcher(url.toString());
+            if (!response.ok) {
+                throw new Error('Pinned repositories request failed');
+            }
+
+            const data = await response.json();
+            if (!Array.isArray(data)) {
+                return [];
+            }
+
+            return data.map((repo) => RepositoryNormalizer.fromPinned(repo));
+        }
+
+        async fetchFromGitHubApi() {
+            const url = `https://api.github.com/users/${this.username}/repos?per_page=100&sort=updated`;
+            const response = await this.fetcher(url);
+            if (!response.ok) {
+                throw new Error('GitHub API request failed');
+            }
+
+            const data = await response.json();
+            if (!Array.isArray(data)) {
+                return [];
+            }
+
+            const filtered = data.filter((repo) => !repo.fork);
+            const normalized = filtered.map((repo) => RepositoryNormalizer.fromGitHub(repo));
+            normalized.sort((a, b) => b.stars - a.stars || new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0));
+            return normalized.slice(0, this.repoLimit);
+        }
+    }
+
+    class RepoRenderer {
+        constructor(container, doc = document) {
+            if (!container) {
+                throw new Error('A container element is required');
+            }
+            this.container = container;
+            this.doc = doc;
+        }
+
+        renderLoading() {
+            this.container.innerHTML = '';
+            const loading = this.doc.createElement('p');
+            loading.className = 'github-projects__status';
+            loading.textContent = 'Loading GitHub projects...';
+            this.container.appendChild(loading);
+        }
+
+        renderError(message) {
+            this.container.innerHTML = '';
+            const error = this.doc.createElement('p');
+            error.className = 'github-projects__status github-projects__status--error';
+            error.textContent = message;
+            this.container.appendChild(error);
+        }
+
+        renderRepositories(repositories) {
+            this.container.innerHTML = '';
+
+            if (!repositories || repositories.length === 0) {
+                this.renderError('No public projects found just yet. Please check back soon!');
+                return;
+            }
+
+            repositories.forEach((repo) => {
+                const card = this.doc.createElement('article');
+                card.className = 'github-projects__card';
+
+                const title = this.doc.createElement('h4');
+                title.className = 'github-projects__card-title';
+                title.textContent = repo.name;
+
+                const description = this.doc.createElement('p');
+                description.className = 'github-projects__card-description';
+                description.textContent = repo.description;
+
+                const meta = this.doc.createElement('p');
+                meta.className = 'github-projects__card-meta';
+                const language = repo.language ? `${repo.language}` : 'Not specified';
+                const stars = `${repo.stars}★`;
+                const updated = repo.updatedAt ? new Date(repo.updatedAt).toLocaleDateString() : 'Recently updated';
+                meta.textContent = `${language} • ${stars} • ${updated}`;
+
+                const link = this.doc.createElement('a');
+                link.className = 'github-projects__card-link';
+                link.href = repo.url;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = 'View on GitHub';
+
+                card.appendChild(title);
+                card.appendChild(description);
+                card.appendChild(meta);
+                card.appendChild(link);
+
+                this.container.appendChild(card);
+            });
+        }
+    }
+
+    class RepoSectionController {
+        constructor({ containerId, username, renderer, apiClient }) {
+            this.containerId = containerId;
+            this.username = username;
+            this.renderer = renderer;
+            this.apiClient = apiClient;
+        }
+
+        async init() {
+            try {
+                const containerElement = this.getContainer();
+                this.renderer = this.renderer || new RepoRenderer(containerElement);
+                this.apiClient = this.apiClient || new GitHubApiClient(this.username);
+
+                this.renderer.renderLoading();
+                const repos = await this.apiClient.fetchRepositories();
+                this.renderer.renderRepositories(repos);
+            } catch (error) {
+                const containerElement = this.safeGetContainer();
+                if (containerElement) {
+                    const fallbackRenderer = this.renderer || new RepoRenderer(containerElement);
+                    fallbackRenderer.renderError('Unable to load GitHub projects right now. Please try again later.');
+                }
+                console.error('Unable to initialize GitHub project section.', error);
+            }
+        }
+
+        getContainer() {
+            const element = this.safeGetContainer();
+            if (!element) {
+                throw new Error(`Container with id "${this.containerId}" not found`);
+            }
+            return element;
+        }
+
+        safeGetContainer() {
+            if (!this.containerId) {
+                return null;
+            }
+            return document.getElementById(this.containerId);
+        }
+    }
+
+    function initializeProjectsSection() {
+        const controller = new RepoSectionController({
+            containerId: 'github-projects',
+            username: 'Ameer-Jamal'
+        });
+        controller.init();
+    }
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initializeProjectsSection);
+        } else {
+            initializeProjectsSection();
+        }
+    }
+
+    const exported = {
+        RepositoryNormalizer,
+        GitHubApiClient,
+        RepoRenderer,
+        RepoSectionController
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = exported;
+    } else {
+        global.GitHubProjects = exported;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/assets/js/githubProjects.js
+++ b/assets/js/githubProjects.js
@@ -57,10 +57,14 @@
             try {
                 const pinnedRepos = await this.fetchPinnedRepositories();
                 if (Array.isArray(pinnedRepos) && pinnedRepos.length > 0) {
+                    console.info('[GitHubProjects] Rendering pinned repositories.', {
+                        username: this.username,
+                        total: pinnedRepos.length
+                    });
                     return pinnedRepos.slice(0, this.repoLimit);
                 }
             } catch (error) {
-                console.warn('Failed to load pinned repositories, falling back to GitHub API.', error);
+                console.warn('[GitHubProjects] Failed to load pinned repositories, falling back to GitHub API.', error);
             }
 
             return this.fetchFromGitHubApi();
@@ -70,8 +74,24 @@
             const url = new URL(this.pinnedServiceUrl);
             url.searchParams.set('username', this.username);
 
-            const response = await this.fetcher(url.toString());
+            console.info('[GitHubProjects] Requesting pinned repositories.', {
+                url: url.toString()
+            });
+
+            let response;
+            try {
+                response = await this.fetcher(url.toString());
+            } catch (error) {
+                console.error('[GitHubProjects] Network error while fetching pinned repositories.', error);
+                throw error;
+            }
             if (!response.ok) {
+                const status = typeof response.status === 'number' ? response.status : 'unknown';
+                const statusText = response.statusText || 'No status text';
+                console.warn('[GitHubProjects] Pinned repositories request failed.', {
+                    status,
+                    statusText
+                });
                 throw new Error('Pinned repositories request failed');
             }
 
@@ -85,8 +105,22 @@
 
         async fetchFromGitHubApi() {
             const url = `https://api.github.com/users/${this.username}/repos?per_page=100&sort=updated`;
-            const response = await this.fetcher(url);
+            console.info('[GitHubProjects] Requesting repositories from GitHub API.', { url });
+
+            let response;
+            try {
+                response = await this.fetcher(url);
+            } catch (error) {
+                console.error('[GitHubProjects] Network error while fetching repositories from GitHub API.', error);
+                throw error;
+            }
             if (!response.ok) {
+                const status = typeof response.status === 'number' ? response.status : 'unknown';
+                const statusText = response.statusText || 'No status text';
+                console.error('[GitHubProjects] GitHub API request failed.', {
+                    status,
+                    statusText
+                });
                 throw new Error('GitHub API request failed');
             }
 
@@ -98,6 +132,10 @@
             const filtered = data.filter((repo) => !repo.fork);
             const normalized = filtered.map((repo) => RepositoryNormalizer.fromGitHub(repo));
             normalized.sort((a, b) => b.stars - a.stars || new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0));
+            console.info('[GitHubProjects] Rendering GitHub API repositories.', {
+                username: this.username,
+                total: normalized.length
+            });
             return normalized.slice(0, this.repoLimit);
         }
     }
@@ -131,6 +169,9 @@
             this.container.innerHTML = '';
 
             if (!repositories || repositories.length === 0) {
+                console.info('[GitHubProjects] No repositories available after fetch.', {
+                    total: repositories ? repositories.length : 0
+                });
                 this.renderError('No public projects found just yet. Please check back soon!');
                 return;
             }
@@ -194,7 +235,7 @@
                     const fallbackRenderer = this.renderer || new RepoRenderer(containerElement);
                     fallbackRenderer.renderError('Unable to load GitHub projects right now. Please try again later.');
                 }
-                console.error('Unable to initialize GitHub project section.', error);
+                console.error('[GitHubProjects] Unable to initialize GitHub project section.', error);
             }
         }
 

--- a/index.html
+++ b/index.html
@@ -86,13 +86,19 @@
 			</article>
 
 			<!-- Work -->
-			<article id="work">
-				<h2 class="major">Projects </h2>
+                        <article id="work">
+                                <h2 class="major">Projects </h2>
+
+                                <section class="github-projects" aria-labelledby="github-projects-title">
+                                        <h3 class="major" id="github-projects-title">Latest GitHub Highlights</h3>
+                                        <p class="github-projects__intro">Here are some of the open-source projects I'm actively working on. These cards update automatically using data from my public GitHub repositories.</p>
+                                        <div class="github-projects__grid" id="github-projects"></div>
+                                </section>
 
 
 
 
-				<h3 class="major">ClassCloud</h3>
+                                <h3 class="major">ClassCloud</h3>
 
 				<span class="image main"><img src="images/ClassCloud-poster.webp" alt="" /></span>
 				<p>ClassCloud is an innovative educational website designed to facilitate
@@ -349,10 +355,11 @@
 
 	<!-- Scripts -->
 	<script src="assets/js/jquery.min.js"></script>
-	<script src="assets/js/browser.min.js"></script>
-	<script src="assets/js/breakpoints.min.js"></script>
-	<script src="assets/js/util.js"></script>
-	<script src="assets/js/main.js"></script>
+        <script src="assets/js/browser.min.js"></script>
+        <script src="assets/js/breakpoints.min.js"></script>
+        <script src="assets/js/util.js"></script>
+        <script src="assets/js/main.js"></script>
+        <script src="assets/js/githubProjects.js"></script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
         <script src="assets/js/breakpoints.min.js"></script>
         <script src="assets/js/util.js"></script>
         <script src="assets/js/main.js"></script>
+        <script src="assets/js/marked.min.js"></script>
         <script src="assets/js/githubProjects.js"></script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ameer-jamal-github-io",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/githubProjects.test.js
+++ b/tests/githubProjects.test.js
@@ -1,0 +1,84 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  RepositoryNormalizer,
+  GitHubApiClient
+} = require('../assets/js/githubProjects.js');
+
+describe('RepositoryNormalizer', () => {
+  test('fromGitHub normalizes repository fields', () => {
+    const normalized = RepositoryNormalizer.fromGitHub({
+      name: 'Demo',
+      description: 'Example project',
+      language: 'JavaScript',
+      html_url: 'https://github.com/demo',
+      stargazers_count: 4,
+      pushed_at: '2023-01-01T00:00:00Z'
+    });
+
+    assert.equal(normalized.name, 'Demo');
+    assert.equal(normalized.description, 'Example project');
+    assert.equal(normalized.language, 'JavaScript');
+    assert.equal(normalized.url, 'https://github.com/demo');
+    assert.equal(normalized.stars, 4);
+    assert.equal(normalized.updatedAt, '2023-01-01T00:00:00Z');
+  });
+
+  test('fromPinned applies sensible defaults when fields are missing', () => {
+    const normalized = RepositoryNormalizer.fromPinned({});
+    assert.equal(normalized.name, 'Untitled Project');
+    assert.equal(normalized.description, 'No description provided.');
+    assert.equal(normalized.language, 'Not specified');
+    assert.equal(normalized.url, '#');
+    assert.equal(normalized.stars, 0);
+    assert.equal(normalized.updatedAt, null);
+  });
+});
+
+describe('GitHubApiClient', () => {
+  test('returns pinned repositories when available', async () => {
+    const pinnedPayload = [
+      { repo: 'PinnedProject', description: 'Pinned', language: 'TypeScript', link: 'https://github.com/pinned', stars: 10 }
+    ];
+
+    const fetchStub = async (url) => ({
+      ok: true,
+      async json() {
+        return pinnedPayload;
+      }
+    });
+
+    const client = new GitHubApiClient('someone', { fetch: fetchStub, repoLimit: 5 });
+    const repos = await client.fetchRepositories();
+    assert.equal(repos.length, 1);
+    assert.equal(repos[0].name, 'PinnedProject');
+    assert.equal(repos[0].stars, 10);
+  });
+
+  test('falls back to GitHub API when pinned request fails', async () => {
+    const githubPayload = [
+      { name: 'Fallback', description: 'Repo', language: 'Python', html_url: 'https://github.com/fallback', stargazers_count: 7, pushed_at: '2023-02-02T00:00:00Z', fork: false },
+      { name: 'Forked', fork: true }
+    ];
+
+    const fetchStub = async (url) => {
+      if (String(url).includes('gh-pinned-repos')) {
+        return { ok: false, async json() { return []; } };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return githubPayload;
+        }
+      };
+    };
+
+    const client = new GitHubApiClient('someone', { fetch: fetchStub, repoLimit: 5 });
+    const repos = await client.fetchRepositories();
+    assert.equal(repos.length, 1);
+    assert.equal(repos[0].name, 'Fallback');
+    assert.equal(repos[0].language, 'Python');
+    assert.equal(repos[0].url, 'https://github.com/fallback');
+  });
+});

--- a/tests/githubProjects.test.js
+++ b/tests/githubProjects.test.js
@@ -27,7 +27,7 @@ describe('RepositoryNormalizer', () => {
   test('fromPinned applies sensible defaults when fields are missing', () => {
     const normalized = RepositoryNormalizer.fromPinned({});
     assert.equal(normalized.name, 'Untitled Project');
-    assert.equal(normalized.description, 'No description provided.');
+    assert.equal(normalized.description, '');
     assert.equal(normalized.language, 'Not specified');
     assert.equal(normalized.url, '#');
     assert.equal(normalized.stars, 0);
@@ -41,29 +41,66 @@ describe('GitHubApiClient', () => {
       { repo: 'PinnedProject', description: 'Pinned', language: 'TypeScript', link: 'https://github.com/pinned', stars: 10 }
     ];
 
-    const fetchStub = async (url) => ({
-      ok: true,
-      async json() {
-        return pinnedPayload;
+    const fetchStub = async (url) => {
+      const stringUrl = String(url);
+      if (stringUrl.includes('gh-pinned-repos')) {
+        return {
+          ok: true,
+          async json() {
+            return pinnedPayload;
+          }
+        };
       }
-    });
+
+      if (stringUrl.includes('/readme')) {
+        return {
+          ok: true,
+          async json() {
+            return {
+              content: Buffer.from('# Hello\nThis is a README').toString('base64'),
+              encoding: 'base64',
+              html_url: 'https://github.com/pinned/blob/main/README.md',
+              download_url: 'https://raw.githubusercontent.com/pinned/main/README.md'
+            };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected URL in fetchStub: ${url}`);
+    };
 
     const client = new GitHubApiClient('someone', { fetch: fetchStub, repoLimit: 5 });
     const repos = await client.fetchRepositories();
     assert.equal(repos.length, 1);
     assert.equal(repos[0].name, 'PinnedProject');
     assert.equal(repos[0].stars, 10);
+    assert.equal(repos[0].readmeRaw.includes('# Hello'), true);
+    assert.equal(repos[0].readmeHtmlUrl, 'https://github.com/pinned/blob/main/README.md');
   });
 
   test('falls back to GitHub API when pinned request fails', async () => {
     const githubPayload = [
-      { name: 'Fallback', description: 'Repo', language: 'Python', html_url: 'https://github.com/fallback', stargazers_count: 7, pushed_at: '2023-02-02T00:00:00Z', fork: false },
+      { name: 'Fallback', description: 'Repo', language: 'Python', html_url: 'https://github.com/fallback', stargazers_count: 7, pushed_at: '2023-02-02T00:00:00Z', fork: false, forks_count: 2, open_issues_count: 1 },
       { name: 'Forked', fork: true }
     ];
 
     const fetchStub = async (url) => {
       if (String(url).includes('gh-pinned-repos')) {
         return { ok: false, async json() { return []; } };
+      }
+
+      if (String(url).includes('/readme')) {
+        return {
+          ok: true,
+          async json() {
+            return {
+              content: Buffer.from('Fallback README content').toString('base64'),
+              encoding: 'base64',
+              html_url: 'https://github.com/fallback/blob/main/README.md',
+              download_url: 'https://raw.githubusercontent.com/fallback/main/README.md'
+            };
+          }
+        };
       }
 
       return {
@@ -80,5 +117,77 @@ describe('GitHubApiClient', () => {
     assert.equal(repos[0].name, 'Fallback');
     assert.equal(repos[0].language, 'Python');
     assert.equal(repos[0].url, 'https://github.com/fallback');
+    assert.equal(repos[0].readmeRaw.includes('Fallback README content'), true);
+  });
+
+  test('returns repositories even when README is missing', async () => {
+    const githubPayload = [
+      { name: 'NoReadmeRepo', description: 'Repo', language: 'Rust', html_url: 'https://github.com/noreadme', stargazers_count: 2, pushed_at: '2023-03-03T00:00:00Z', fork: false }
+    ];
+
+    const fetchStub = async (url) => {
+      if (String(url).includes('gh-pinned-repos')) {
+        return { ok: false, async json() { return []; } };
+      }
+
+      if (String(url).includes('/readme')) {
+        return { status: 404, ok: false, async json() { return {}; } };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return githubPayload;
+        }
+      };
+    };
+
+    const client = new GitHubApiClient('someone', { fetch: fetchStub });
+    const repos = await client.fetchRepositories();
+    assert.equal(repos.length, 1);
+    assert.equal(repos[0].name, 'NoReadmeRepo');
+    assert.equal(repos[0].readmeRaw, null);
+    assert.equal(repos[0].readmeHtmlUrl, 'https://github.com/noreadme');
+  });
+
+  test('excludes configured repositories from results', async () => {
+    const githubPayload = [
+      { name: 'Ameer-Jamal', description: 'Personal profile', language: 'HTML', html_url: 'https://github.com/Ameer-Jamal', stargazers_count: 5, pushed_at: '2024-01-01T00:00:00Z', fork: false },
+      { name: 'Ameer-Jamal.github.io', description: 'Portfolio site', language: 'HTML', html_url: 'https://github.com/Ameer-Jamal/Ameer-Jamal.github.io', stargazers_count: 10, pushed_at: '2024-02-01T00:00:00Z', fork: false },
+      { name: 'ShownProject', description: 'Visible repo', language: 'TypeScript', html_url: 'https://github.com/Ameer-Jamal/shown', stargazers_count: 3, pushed_at: '2024-03-01T00:00:00Z', fork: false }
+    ];
+
+    const fetchStub = async (url) => {
+      if (String(url).includes('gh-pinned-repos')) {
+        return { ok: false, async json() { return []; } };
+      }
+
+      if (String(url).includes('/readme')) {
+        return {
+          ok: true,
+          async json() {
+            return {
+              content: Buffer.from('Visible README content').toString('base64'),
+              encoding: 'base64',
+              html_url: 'https://github.com/Ameer-Jamal/shown/blob/main/README.md',
+              download_url: 'https://raw.githubusercontent.com/Ameer-Jamal/shown/main/README.md'
+            };
+          }
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return githubPayload;
+        }
+      };
+    };
+
+    const client = new GitHubApiClient('Ameer-Jamal', { fetch: fetchStub });
+    const repos = await client.fetchRepositories();
+    assert.equal(repos.length, 1);
+    assert.equal(repos[0].name, 'ShownProject');
+    assert.equal(repos[0].readmeRaw.includes('Visible README content'), true);
   });
 });


### PR DESCRIPTION
## Summary
- add an auto-updating GitHub highlights section to the Projects page
- implement modular JavaScript services to fetch, normalize, and render repository data with graceful fallbacks
- refresh styling for the new grid and add Node-based unit tests with an npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6907fd88e87c8321a12cf3e845d9cf42